### PR TITLE
Add simple upload-based streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+public/uploads/*
+!public/uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Claude François Forever Streaming
+
+This project is a small proof‑of‑concept for uploading and streaming your own shows using [Next.js](https://nextjs.org/).
+
+## Getting Started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Run the development server
+   ```bash
+   npm run dev
+   ```
+3. Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+Uploaded videos are stored in `public/uploads/`. The folder contains a `.gitkeep` file so it is tracked while ignoring uploaded media.

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "start": "next start"
   },
   "dependencies": {
+    "autoprefixer": "^10.4.16",
+    "formidable": "^3.5.0",
+    "lucide-react": "0.331.0",
     "next": "14.1.0",
+    "next-auth": "4.24.0",
+    "postcss": "^8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "lucide-react": "0.331.0",
-    "autoprefixer": "^10.4.16",
-    "postcss": "^8.4.27",
-    "tailwindcss": "3.4.0",
-    "next-auth": "4.24.0"
+    "tailwindcss": "3.4.0"
   }
 }

--- a/pages/api/upload.js
+++ b/pages/api/upload.js
@@ -1,0 +1,28 @@
+import fs from 'fs'
+import path from 'path'
+import formidable from 'formidable'
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
+
+  const form = formidable({ multiples: false, uploadDir: path.join(process.cwd(), 'public/uploads'), keepExtensions: true })
+  form.parse(req, (err, fields, files) => {
+    if (err || !files.file) {
+      res.status(400).json({ error: 'Upload failed' })
+      return
+    }
+    const file = files.file
+    const newPath = path.join(process.cwd(), 'public/uploads', file.newFilename)
+    fs.renameSync(file.filepath, newPath)
+    res.status(200).json({ name: file.newFilename })
+  })
+}

--- a/pages/api/videos.js
+++ b/pages/api/videos.js
@@ -1,0 +1,11 @@
+import fs from 'fs'
+import path from 'path'
+
+export default function handler(req, res) {
+  const dir = path.join(process.cwd(), 'public/uploads')
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+  const files = fs.readdirSync(dir).filter(f => f !== '.gitkeep')
+  res.status(200).json(files)
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+
+export default function Home() {
+  const [videos, setVideos] = useState([])
+  const [file, setFile] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/videos')
+      .then(res => res.json())
+      .then(setVideos)
+  }, [])
+
+  const handleUpload = async (e) => {
+    e.preventDefault()
+    if (!file) return
+    const formData = new FormData()
+    formData.append('file', file)
+    await fetch('/api/upload', {
+      method: 'POST',
+      body: formData
+    })
+    setFile(null)
+    e.target.reset()
+    const updated = await fetch('/api/videos').then(r => r.json())
+    setVideos(updated)
+  }
+
+  return (
+    <div className="container mx-auto p-4 text-gray-200 bg-[#0D0B1E] min-h-screen">
+      <h1 className="text-3xl font-serif text-purple-300 mb-6 text-center">Claude François Forever Streaming</h1>
+      <form onSubmit={handleUpload} className="mb-6">
+        <input type="file" onChange={e => setFile(e.target.files[0])} className="mb-2" />
+        <button className="bg-purple-900 text-white px-3 py-1 rounded" type="submit">Uploader</button>
+      </form>
+      <ul>
+        {videos.map(v => (
+          <li key={v} className="mb-4">
+            <video controls className="w-full max-w-lg">
+              <source src={`/uploads/${v}`} />
+            </video>
+            <p className="mt-2">{v}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `.gitignore`
- add video upload page and API routes
- track public uploads directory with `.gitkeep`
- document setup in README

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854320a92cc832c838f53e2ae263bd1